### PR TITLE
Update COD URL

### DIFF
--- a/jsme-hall-of-fame.html
+++ b/jsme-hall-of-fame.html
@@ -44,7 +44,7 @@ If you have also a web page that uses the JSME and want it to be added here, dro
 <h2>Scientific Databases</h2>
 <a href="https://bmrb.io/jsmol/jsmol_14.29.46/jsv_jme.htm">Biological magnetic resonance data bank - an example of JSME integration</a><br>
 <a href="https://www.brenda-enzymes.org/structure_search.php">BRENDA - the comprehensive enzyme information system</a><br>
-<a href="https://www.compoundsearch.com/index_ss.html">Compound searching in in various spectral databases.</a><br>
+<a href="https://www.compoundsearch.com/index_ss.html">Compound searching in various spectral databases.</a><br>
 <a href="https://www.crystallography.net/cod/jsme_search.html">Crystallography Open Database</a><br>
 <a href="http://www.cbrg.riken.jp/npedia/">Natural Products Encyclopedia at RIKEN</a><br>
 <a href="https://ochem.eu/home/show.do">OCHEM - online chemical database</a><br>

--- a/jsme-hall-of-fame.html
+++ b/jsme-hall-of-fame.html
@@ -45,7 +45,7 @@ If you have also a web page that uses the JSME and want it to be added here, dro
 <a href="https://bmrb.io/jsmol/jsmol_14.29.46/jsv_jme.htm">Biological magnetic resonance data bank - an example of JSME integration</a><br>
 <a href="https://www.brenda-enzymes.org/structure_search.php">BRENDA - the comprehensive enzyme information system</a><br>
 <a href="https://www.compoundsearch.com/index_ss.html">Compound searching in in various spectral databases.</a><br>
-<a href="http://qiserver.ugr.es/cod/jsme_search.html">Crystallography Open Database</a><br>
+<a href="https://www.crystallography.net/cod/jsme_search.html">Crystallography Open Database</a><br>
 <a href="http://www.cbrg.riken.jp/npedia/">Natural Products Encyclopedia at RIKEN</a><br>
 <a href="https://ochem.eu/home/show.do">OCHEM - online chemical database</a><br>
 <a href="https://www.organische-chemie.ch/OC/chemikalien/struktursuche.htm">Organic chemistry portal - structure search</a><br>


### PR DESCRIPTION
The old URL points to a mirror of the COD instead of the main one.